### PR TITLE
Ignore Eclipse project files and .class files in bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+
+.classpath
+.project


### PR DESCRIPTION
These files are specific for personal Eclipse workspaces and are not needed in a public repository. The .class files are also unneeded as work is done on the .java files in src and the class files just serve to add to the clutter.